### PR TITLE
typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
                                 <a href="https://plus.google.com/communities/110811566242871492162">Google plus</a>
                             </li>
                             <li>
-                                <a href="https://www.instagram.com/retromusicapp">Instagrm</a>
+                                <a href="https://www.instagram.com/retromusicapp">Instagram</a>
                             </li>
                             <li>
                                 <a href="https://www.t.me/retromusicapp">Telegram</a>


### PR DESCRIPTION
there was a typo written in the instagram link, it was "instagrm". It was visible through the main website so i think it's necessary to fix it.